### PR TITLE
Add prefix/suffix search helpers

### DIFF
--- a/jsstr.c
+++ b/jsstr.c
@@ -205,6 +205,52 @@ int jsstr32_concat(jsstr32_t *s, jsstr32_t *src) {
     return 0; /* success */
 }
 
+int jsstr32_u32_startswith(jsstr32_t *s, jsstr32_t *prefix) {
+    if (prefix->len > s->len) {
+        return 0;
+    }
+    for (size_t i = 0; i < prefix->len; i++) {
+        if (s->codepoints[i] != prefix->codepoints[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int jsstr32_u32_endswith(jsstr32_t *s, jsstr32_t *suffix) {
+    if (suffix->len > s->len) {
+        return 0;
+    }
+    size_t start = s->len - suffix->len;
+    for (size_t i = 0; i < suffix->len; i++) {
+        if (s->codepoints[start + i] != suffix->codepoints[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int jsstr32_u32_includes(jsstr32_t *s, jsstr32_t *search) {
+    if (search->len == 0) {
+        return 1;
+    }
+    if (search->len > s->len) {
+        return 0;
+    }
+    for (size_t i = 0; i <= s->len - search->len; i++) {
+        size_t j;
+        for (j = 0; j < search->len; j++) {
+            if (s->codepoints[i + j] != search->codepoints[j]) {
+                break;
+            }
+        }
+        if (j == search->len) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 void jsstr16_init(jsstr16_t *s) {
     s->cap = 0;
     s->len = 0;
@@ -537,6 +583,52 @@ void jsstr16_u32_truncate(jsstr16_t *s, size_t len) {
     }
 }
 
+int jsstr16_u16_startswith(jsstr16_t *s, jsstr16_t *prefix) {
+    if (prefix->len > s->len) {
+        return 0;
+    }
+    for (size_t i = 0; i < prefix->len; i++) {
+        if (s->codeunits[i] != prefix->codeunits[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int jsstr16_u16_endswith(jsstr16_t *s, jsstr16_t *suffix) {
+    if (suffix->len > s->len) {
+        return 0;
+    }
+    size_t start = s->len - suffix->len;
+    for (size_t i = 0; i < suffix->len; i++) {
+        if (s->codeunits[start + i] != suffix->codeunits[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int jsstr16_u16_includes(jsstr16_t *s, jsstr16_t *search) {
+    if (search->len == 0) {
+        return 1;
+    }
+    if (search->len > s->len) {
+        return 0;
+    }
+    for (size_t i = 0; i <= s->len - search->len; i++) {
+        size_t j;
+        for (j = 0; j < search->len; j++) {
+            if (s->codeunits[i + j] != search->codeunits[j]) {
+                break;
+            }
+        }
+        if (j == search->len) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 int jsstr16_concat(jsstr16_t *s, jsstr16_t *src) {
     /* concatenate src to s, if there is enough capacity */
     if (s->len + src->len > s->cap) {
@@ -697,6 +789,52 @@ ssize_t jsstr8_u32_indextoken(jsstr8_t *s, uint32_t *search_c, size_t c_len, siz
 
     }
     return -i;
+}
+
+int jsstr8_u8_startswith(jsstr8_t *s, jsstr8_t *prefix) {
+    if (prefix->len > s->len) {
+        return 0;
+    }
+    for (size_t i = 0; i < prefix->len; i++) {
+        if (s->bytes[i] != prefix->bytes[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int jsstr8_u8_endswith(jsstr8_t *s, jsstr8_t *suffix) {
+    if (suffix->len > s->len) {
+        return 0;
+    }
+    size_t start = s->len - suffix->len;
+    for (size_t i = 0; i < suffix->len; i++) {
+        if (s->bytes[start + i] != suffix->bytes[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int jsstr8_u8_includes(jsstr8_t *s, jsstr8_t *search) {
+    if (search->len == 0) {
+        return 1;
+    }
+    if (search->len > s->len) {
+        return 0;
+    }
+    for (size_t i = 0; i <= s->len - search->len; i++) {
+        size_t j;
+        for (j = 0; j < search->len; j++) {
+            if (s->bytes[i + j] != search->bytes[j]) {
+                break;
+            }
+        }
+        if (j == search->len) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 size_t jsstr8_get_cap(jsstr8_t *s) {

--- a/jsstr.h
+++ b/jsstr.h
@@ -145,6 +145,9 @@ void jsstr32_u32_slice(jsstr32_t *s, jsstr32_t *src, size_t start_i, ssize_t sto
  * Compare two jsstr32_t strings as UTF-32 code points.
  */
 int jsstr32_u32_cmp(jsstr32_t *s1, jsstr32_t *s2);
+int jsstr32_u32_startswith(jsstr32_t *s, jsstr32_t *prefix);
+int jsstr32_u32_endswith(jsstr32_t *s, jsstr32_t *suffix);
+int jsstr32_u32_includes(jsstr32_t *s, jsstr32_t *search);
 
 /*
  * Find the index of the first occurrence of the code point in the string.
@@ -204,6 +207,9 @@ void jsstr16_u16_slice(jsstr16_t *s, jsstr16_t *src, size_t start_i, ssize_t sto
 void jsstr16_u32_slice(jsstr16_t *s, jsstr16_t *src, size_t start_i, ssize_t stop_i);
 int jsstr16_u16_cmp(jsstr16_t *s1, jsstr16_t *s2);
 int jsstr16_u32_cmp(jsstr16_t *s1, jsstr16_t *s2);
+int jsstr16_u16_startswith(jsstr16_t *s, jsstr16_t *prefix);
+int jsstr16_u16_endswith(jsstr16_t *s, jsstr16_t *suffix);
+int jsstr16_u16_includes(jsstr16_t *s, jsstr16_t *search);
 ssize_t jsstr16_u16_indexof(jsstr16_t *s, uint16_t search_c, size_t start_i);
 ssize_t jsstr16_u32_indexof(jsstr16_t *s, uint32_t search_c, size_t start_i);
 ssize_t jsstr16_u16_indextoken(jsstr16_t *s, uint16_t *search_c, size_t search_c_len, size_t start_i);
@@ -251,6 +257,9 @@ void jsstr8_u8_slice(jsstr8_t *s, jsstr8_t *src, size_t start_i, ssize_t stop_i)
 void jsstr8_u32_slice(jsstr8_t *s, jsstr8_t *src, size_t start_i, ssize_t stop_i);
 int jsstr8_u8_cmp(jsstr8_t *s1, jsstr8_t *s2);
 int jsstr8_u32_cmp(jsstr8_t *s1, jsstr8_t *s2);
+int jsstr8_u8_startswith(jsstr8_t *s, jsstr8_t *prefix);
+int jsstr8_u8_endswith(jsstr8_t *s, jsstr8_t *suffix);
+int jsstr8_u8_includes(jsstr8_t *s, jsstr8_t *search);
 ssize_t jsstr8_u8_indexof(jsstr8_t *s, uint8_t search_c, size_t start_i);
 ssize_t jsstr8_u32_indexof(jsstr8_t *s, uint32_t search_c, size_t start_i);
 ssize_t jsstr8_u8_indextoken(jsstr8_t *s, uint8_t *search_c, size_t search_c_len, size_t start_i);

--- a/test_jsstr.c
+++ b/test_jsstr.c
@@ -87,6 +87,16 @@ void test_jsstr32_lifecycle() {
     size_t search_tok_len = utf32_strlen(search_tok);
     printf("jsstr32_u32_indextoken: %zd\n",
            jsstr32_u32_indextoken(&s, search_tok, search_tok_len, start_i));
+
+    jsstr32_t prefix;
+    jsstr32_t suffix;
+    jsstr32_t sub;
+    jsstr32_init_from_str(&prefix, L"Hello");
+    jsstr32_init_from_str(&suffix, L"World!");
+    jsstr32_init_from_str(&sub, L", Wo");
+    printf("jsstr32_u32_startswith: %d\n", jsstr32_u32_startswith(&s, &prefix));
+    printf("jsstr32_u32_endswith: %d\n", jsstr32_u32_endswith(&s, &suffix));
+    printf("jsstr32_u32_includes: %d\n", jsstr32_u32_includes(&s, &sub));
 }
 
 void test_jsstr16_lifecycle() {
@@ -210,6 +220,16 @@ void test_jsstr16_lifecycle() {
     /* test cmp */
     jsstr16_init_from_str(&s_cmp, utf16_str);
     printf("jsstr16_u32_cmp: %d\n", jsstr16_u32_cmp(&s_str, &s_cmp));
+
+    jsstr16_t prefix;
+    jsstr16_t suffix;
+    jsstr16_t sub;
+    jsstr16_init_from_str(&prefix, (uint16_t *)L"Hello");
+    jsstr16_init_from_str(&suffix, (uint16_t *)L"World!");
+    jsstr16_init_from_str(&sub, (uint16_t *)L", Wo");
+    printf("jsstr16_u16_startswith: %d\n", jsstr16_u16_startswith(&s_str, &prefix));
+    printf("jsstr16_u16_endswith: %d\n", jsstr16_u16_endswith(&s_str, &suffix));
+    printf("jsstr16_u16_includes: %d\n", jsstr16_u16_includes(&s_str, &sub));
 }
 
 void test_jsstr8_lifecycle() {
@@ -325,6 +345,16 @@ void test_jsstr8_lifecycle() {
     /* test cmp */
     jsstr8_init_from_str(&s_cmp, "Hello, World!");
     printf("jsstr8_u32_cmp: %d\n", jsstr8_u32_cmp(&s_str, &s_cmp));
+
+    jsstr8_t prefix;
+    jsstr8_t suffix;
+    jsstr8_t sub;
+    jsstr8_init_from_str(&prefix, "Hello");
+    jsstr8_init_from_str(&suffix, "World!");
+    jsstr8_init_from_str(&sub, ", Wo");
+    printf("jsstr8_u8_startswith: %d\n", jsstr8_u8_startswith(&s_str, &prefix));
+    printf("jsstr8_u8_endswith: %d\n", jsstr8_u8_endswith(&s_str, &suffix));
+    printf("jsstr8_u8_includes: %d\n", jsstr8_u8_includes(&s_str, &sub));
 }
 
 


### PR DESCRIPTION
## Summary
- implement simple startswith, endswith, and includes for jsstr32, jsstr16 and jsstr8
- expose the new helpers in the public header
- demo the operations in the jsstr test program

## Testing
- `make test_jsstr`
- `make test_mnurl`
- `make test_utf8`


------
https://chatgpt.com/codex/tasks/task_e_685dbee191f88333b521db9bee654147