### PR TITLE
Add well-formed prototypes

### DIFF
--- a/jsstr.h
+++ b/jsstr.h
@@ -121,6 +121,9 @@ size_t jsstr32_get_utf16len(jsstr32_t *s);
  */
 size_t jsstr32_get_utf8len(jsstr32_t *s);
 
+int jsstr32_is_well_formed(jsstr32_t *s);
+void jsstr32_to_well_formed(jsstr32_t *s);
+
 /*
  * Get the code point at the given index.
  * Returns a pointer to the code point, or NULL if out of bounds.
@@ -199,6 +202,7 @@ size_t jsstr16_get_utf16len(jsstr16_t *s);
 size_t jsstr16_get_utf8len(jsstr16_t *s);
 
 int jsstr16_is_well_formed(jsstr16_t *s);
+void jsstr16_to_well_formed(jsstr16_t *s);
 
 uint16_t *jsstr16_u16s_at(jsstr16_t *s, size_t i);
 uint16_t *jsstr16_u32s_at(jsstr16_t *s, size_t i);
@@ -256,6 +260,7 @@ size_t jsstr8_get_utf16len(jsstr8_t *s);
 size_t jsstr8_get_utf8len(jsstr8_t *s);
 
 int jsstr8_is_well_formed(jsstr8_t *s);
+size_t jsstr8_to_well_formed(jsstr8_t *s, jsstr8_t *dest);
 
 uint8_t *jsstr8_u8s_at(jsstr8_t *s, size_t i);
 uint8_t *jsstr8_u32s_at(jsstr8_t *s, size_t i);

--- a/test_jsstr.c
+++ b/test_jsstr.c
@@ -407,11 +407,59 @@ void test_jsstr8_lifecycle() {
     printf("jsstr8_repeat len: %zu\n", jsstr8_get_utf8len(&dest8));
 }
 
+void test_jsstr32_well_formed() {
+    jsstr32_t valid;
+    jsstr32_init_from_str(&valid, L"A");
+    printf("jsstr32_is_well_formed (valid): %d\n", jsstr32_is_well_formed(&valid));
+
+    uint32_t invalid_buf[2] = {0xD800, 'A'};
+    jsstr32_t invalid = {2, 2, invalid_buf};
+    printf("jsstr32_is_well_formed (invalid): %d\n", jsstr32_is_well_formed(&invalid));
+    jsstr32_to_well_formed(&invalid);
+    printf("jsstr32_is_well_formed (after): %d\n", jsstr32_is_well_formed(&invalid));
+    printf("jsstr32_to_well_formed char: %04x\n", invalid.codepoints[0]);
+}
+
+void test_jsstr16_well_formed() {
+    uint16_t valid_buf[1] = {'A'};
+    jsstr16_t valid = {1, 1, valid_buf};
+    printf("jsstr16_is_well_formed (valid): %d\n", jsstr16_is_well_formed(&valid));
+
+    uint16_t invalid_buf[2] = {0xD800, 'A'};
+    jsstr16_t invalid = {2, 2, invalid_buf};
+    printf("jsstr16_is_well_formed (invalid): %d\n", jsstr16_is_well_formed(&invalid));
+    jsstr16_to_well_formed(&invalid);
+    printf("jsstr16_is_well_formed (after): %d\n", jsstr16_is_well_formed(&invalid));
+    printf("jsstr16_to_well_formed char: %04x %04x\n", invalid.codeunits[0], invalid.codeunits[1]);
+}
+
+void test_jsstr8_well_formed() {
+    uint8_t valid_buf[1] = {'A'};
+    jsstr8_t valid = {1, 1, valid_buf};
+    printf("jsstr8_is_well_formed (valid): %d\n", jsstr8_is_well_formed(&valid));
+
+    uint8_t invalid_buf[3] = {0xE2, 0x82, 'A'};
+    jsstr8_t invalid = {3, 3, invalid_buf};
+    printf("jsstr8_is_well_formed (invalid): %d\n", jsstr8_is_well_formed(&invalid));
+    uint8_t dest_buf[8];
+    jsstr8_t dest = {sizeof(dest_buf), 0, dest_buf};
+    jsstr8_to_well_formed(&invalid, &dest);
+    printf("jsstr8_is_well_formed (after): %d\n", jsstr8_is_well_formed(&dest));
+    printf("jsstr8_to_well_formed bytes: ");
+    for (size_t i = 0; i < dest.len; i++) {
+        printf("%02x ", dest.bytes[i]);
+    }
+    printf("\n");
+}
+
 
 int main() {
     setlocale(LC_ALL, "");
     test_jsstr32_lifecycle();
     test_jsstr16_lifecycle();
     test_jsstr8_lifecycle();
+    test_jsstr32_well_formed();
+    test_jsstr16_well_formed();
+    test_jsstr8_well_formed();
     return 0;
 }


### PR DESCRIPTION
## Summary
- expose jsstr*_to_well_formed helpers in jsstr.h
- expose jsstr32_is_well_formed prototype
- run the well-formedness tests

## Testing
- `make test_jsstr`

------
https://chatgpt.com/codex/tasks/task_e_685e21951adc83338fbd635d0525754b