### PR TITLE
Implement pad and trim string methods

### DIFF
--- a/jsstr.c
+++ b/jsstr.c
@@ -243,6 +243,60 @@ int jsstr32_repeat(jsstr32_t *dest, jsstr32_t *src, size_t count) {
     return 0;
 }
 
+void jsstr32_pad_start(jsstr32_t *s, size_t target_len) {
+    if (s->len >= target_len) {
+        return;
+    }
+    size_t add = target_len - s->len;
+    if (target_len > s->cap) {
+        add = s->cap - s->len;
+    }
+    if (add == 0) {
+        return;
+    }
+    memmove(s->codepoints + add, s->codepoints, s->len * sizeof(uint32_t));
+    for (size_t i = 0; i < add; i++) {
+        s->codepoints[i] = 0x20;
+    }
+    s->len += add;
+}
+
+void jsstr32_pad_end(jsstr32_t *s, size_t target_len) {
+    if (s->len >= target_len) {
+        return;
+    }
+    size_t add = target_len - s->len;
+    if (target_len > s->cap) {
+        add = s->cap - s->len;
+    }
+    for (size_t i = 0; i < add; i++) {
+        s->codepoints[s->len + i] = 0x20;
+    }
+    s->len += add;
+}
+
+void jsstr32_trim_start(jsstr32_t *s) {
+    size_t i = 0;
+    while (i < s->len && iswspace((wint_t)s->codepoints[i])) {
+        i++;
+    }
+    if (i > 0) {
+        memmove(s->codepoints, s->codepoints + i, (s->len - i) * sizeof(uint32_t));
+        s->len -= i;
+    }
+}
+
+void jsstr32_trim_end(jsstr32_t *s) {
+    while (s->len > 0 && iswspace((wint_t)s->codepoints[s->len - 1])) {
+        s->len--;
+    }
+}
+
+void jsstr32_trim(jsstr32_t *s) {
+    jsstr32_trim_start(s);
+    jsstr32_trim_end(s);
+}
+
 int jsstr32_u32_startswith(jsstr32_t *s, jsstr32_t *prefix) {
     if (prefix->len > s->len) {
         return 0;
@@ -771,6 +825,60 @@ int jsstr16_repeat(jsstr16_t *dest, jsstr16_t *src, size_t count) {
     return 0;
 }
 
+void jsstr16_pad_start(jsstr16_t *s, size_t target_len) {
+    if (s->len >= target_len) {
+        return;
+    }
+    size_t add = target_len - s->len;
+    if (target_len > s->cap) {
+        add = s->cap - s->len;
+    }
+    if (add == 0) {
+        return;
+    }
+    memmove(s->codeunits + add, s->codeunits, s->len * sizeof(uint16_t));
+    for (size_t i = 0; i < add; i++) {
+        s->codeunits[i] = 0x20;
+    }
+    s->len += add;
+}
+
+void jsstr16_pad_end(jsstr16_t *s, size_t target_len) {
+    if (s->len >= target_len) {
+        return;
+    }
+    size_t add = target_len - s->len;
+    if (target_len > s->cap) {
+        add = s->cap - s->len;
+    }
+    for (size_t i = 0; i < add; i++) {
+        s->codeunits[s->len + i] = 0x20;
+    }
+    s->len += add;
+}
+
+void jsstr16_trim_start(jsstr16_t *s) {
+    size_t i = 0;
+    while (i < s->len && iswspace((wint_t)s->codeunits[i])) {
+        i++;
+    }
+    if (i > 0) {
+        memmove(s->codeunits, s->codeunits + i, (s->len - i) * sizeof(uint16_t));
+        s->len -= i;
+    }
+}
+
+void jsstr16_trim_end(jsstr16_t *s) {
+    while (s->len > 0 && iswspace((wint_t)s->codeunits[s->len - 1])) {
+        s->len--;
+    }
+}
+
+void jsstr16_trim(jsstr16_t *s) {
+    jsstr16_trim_start(s);
+    jsstr16_trim_end(s);
+}
+
 void jsstr8_init(jsstr8_t *s) {
     s->cap = 0;
     s->len = 0;
@@ -1216,4 +1324,54 @@ int jsstr8_repeat(jsstr8_t *dest, jsstr8_t *src, size_t count) {
     }
     dest->len = src->len * count;
     return 0;
+}
+
+void jsstr8_pad_start(jsstr8_t *s, size_t target_len) {
+    if (s->len >= target_len) {
+        return;
+    }
+    size_t add = target_len - s->len;
+    if (target_len > s->cap) {
+        add = s->cap - s->len;
+    }
+    if (add == 0) {
+        return;
+    }
+    memmove(s->bytes + add, s->bytes, s->len);
+    memset(s->bytes, ' ', add);
+    s->len += add;
+}
+
+void jsstr8_pad_end(jsstr8_t *s, size_t target_len) {
+    if (s->len >= target_len) {
+        return;
+    }
+    size_t add = target_len - s->len;
+    if (target_len > s->cap) {
+        add = s->cap - s->len;
+    }
+    memset(s->bytes + s->len, ' ', add);
+    s->len += add;
+}
+
+void jsstr8_trim_start(jsstr8_t *s) {
+    size_t i = 0;
+    while (i < s->len && isspace((unsigned char)s->bytes[i])) {
+        i++;
+    }
+    if (i > 0) {
+        memmove(s->bytes, s->bytes + i, s->len - i);
+        s->len -= i;
+    }
+}
+
+void jsstr8_trim_end(jsstr8_t *s) {
+    while (s->len > 0 && isspace((unsigned char)s->bytes[s->len - 1])) {
+        s->len--;
+    }
+}
+
+void jsstr8_trim(jsstr8_t *s) {
+    jsstr8_trim_start(s);
+    jsstr8_trim_end(s);
 }

--- a/jsstr.h
+++ b/jsstr.h
@@ -171,6 +171,11 @@ int jsstr32_concat(jsstr32_t *s, jsstr32_t *src);
 void jsstr32_u32_tolower(jsstr32_t *s);
 void jsstr32_u32_toupper(jsstr32_t *s);
 int jsstr32_repeat(jsstr32_t *dest, jsstr32_t *src, size_t count);
+void jsstr32_pad_start(jsstr32_t *s, size_t target_len);
+void jsstr32_pad_end(jsstr32_t *s, size_t target_len);
+void jsstr32_trim(jsstr32_t *s);
+void jsstr32_trim_start(jsstr32_t *s);
+void jsstr32_trim_end(jsstr32_t *s);
 
 /*
  * UTF-16 strings
@@ -229,6 +234,11 @@ void jsstr16_u16_toupper(jsstr16_t *s);
 void jsstr16_u32_tolower(jsstr16_t *s);
 void jsstr16_u32_toupper(jsstr16_t *s);
 int jsstr16_repeat(jsstr16_t *dest, jsstr16_t *src, size_t count);
+void jsstr16_pad_start(jsstr16_t *s, size_t target_len);
+void jsstr16_pad_end(jsstr16_t *s, size_t target_len);
+void jsstr16_trim(jsstr16_t *s);
+void jsstr16_trim_start(jsstr16_t *s);
+void jsstr16_trim_end(jsstr16_t *s);
 
 /*
  * UTF-8 strings
@@ -287,5 +297,10 @@ void jsstr8_u8_toupper(jsstr8_t *s);
 void jsstr8_u32_tolower(jsstr8_t *s);
 void jsstr8_u32_toupper(jsstr8_t *s);
 int jsstr8_repeat(jsstr8_t *dest, jsstr8_t *src, size_t count);
+void jsstr8_pad_start(jsstr8_t *s, size_t target_len);
+void jsstr8_pad_end(jsstr8_t *s, size_t target_len);
+void jsstr8_trim(jsstr8_t *s);
+void jsstr8_trim_start(jsstr8_t *s);
+void jsstr8_trim_end(jsstr8_t *s);
 
 #endif

--- a/test_jsstr.c
+++ b/test_jsstr.c
@@ -110,6 +110,15 @@ void test_jsstr32_lifecycle() {
     jsstr32_init_from_buf(&dest, (char *)dest_buf, dest_len);
     jsstr32_repeat(&dest, &s, 3);
     printf("jsstr32_repeat len: %zu\n", jsstr32_get_utf32len(&dest));
+
+    jsstr32_init_from_buf(&s, (char *)buf, len);
+    jsstr32_set_from_utf32(&s, L"  abc  ", 7);
+    jsstr32_trim(&s);
+    printf("jsstr32_trim len: %zu\n", jsstr32_get_utf32len(&s));
+    jsstr32_pad_start(&s, 6);
+    printf("jsstr32_pad_start len: %zu\n", jsstr32_get_utf32len(&s));
+    jsstr32_pad_end(&s, 8);
+    printf("jsstr32_pad_end len: %zu\n", jsstr32_get_utf32len(&s));
 }
 
 void test_jsstr16_lifecycle() {
@@ -263,6 +272,18 @@ void test_jsstr16_lifecycle() {
     jsstr16_init_from_buf(&dest16, (char *)dest16_buf, dest16_len);
     jsstr16_repeat(&dest16, &s, 3);
     printf("jsstr16_repeat len: %zu\n", jsstr16_get_utf16len(&dest16));
+
+    jsstr16_init_from_buf(&s, (char *)buf, len);
+    {
+        uint16_t tmp[] = { ' ', ' ', 'a', 'b', 'c', ' ', 0 };
+        jsstr16_set_from_utf16(&s, tmp, 6);
+    }
+    jsstr16_trim(&s);
+    printf("jsstr16_trim len: %zu\n", jsstr16_get_utf32len(&s));
+    jsstr16_pad_start(&s, 6);
+    printf("jsstr16_pad_start len: %zu\n", jsstr16_get_utf32len(&s));
+    jsstr16_pad_end(&s, 8);
+    printf("jsstr16_pad_end len: %zu\n", jsstr16_get_utf32len(&s));
 }
 
 void test_jsstr8_lifecycle() {
@@ -405,6 +426,15 @@ void test_jsstr8_lifecycle() {
     jsstr8_init_from_buf(&dest8, (char *)dest8_buf, dest8_len);
     jsstr8_repeat(&dest8, &s, 3);
     printf("jsstr8_repeat len: %zu\n", jsstr8_get_utf8len(&dest8));
+
+    jsstr8_init_from_buf(&s, (char *)buf, len);
+    jsstr8_set_from_utf8(&s, (uint8_t *)"  abc ", 6);
+    jsstr8_trim(&s);
+    printf("jsstr8_trim len: %zu\n", jsstr8_get_utf8len(&s));
+    jsstr8_pad_start(&s, 6);
+    printf("jsstr8_pad_start len: %zu\n", jsstr8_get_utf8len(&s));
+    jsstr8_pad_end(&s, 8);
+    printf("jsstr8_pad_end len: %zu\n", jsstr8_get_utf8len(&s));
 }
 
 void test_jsstr32_well_formed() {


### PR DESCRIPTION
## Summary
- add pad and trim helpers to jsstr32/16/8
- expose the new methods in the header
- extend jsstr tests to cover new functions

## Testing
- `make test_jsstr`

------
https://chatgpt.com/codex/tasks/task_e_685f7fe0f1208333ba08b23a16577cd7