### PR TITLE
Add pluggable locale interface

### DIFF
--- a/jsstr.c
+++ b/jsstr.c
@@ -3,6 +3,56 @@
 #include "jsstr.h"
 #include "utf8.h"
 
+/*
+ * Locale helpers
+ *
+ * The build system can define JS_USE_LIBC_LOCALE or JS_USE_ICU_LOCALE to
+ * enable locale-aware conversions using libc or ICU respectively.  If none are
+ * defined, a small ASCII-only fallback is used instead.
+ */
+
+#ifndef JS_USE_ICU_LOCALE
+#define JS_USE_ICU_LOCALE 0
+#endif
+#ifndef JS_USE_LIBC_LOCALE
+#define JS_USE_LIBC_LOCALE 0
+#endif
+
+#if JS_USE_ICU_LOCALE
+#include <unicode/uchar.h>
+#define JS_LOCALE_TO_LOWER(cp) ((uint32_t)u_tolower(cp))
+#define JS_LOCALE_TO_UPPER(cp) ((uint32_t)u_toupper(cp))
+#define JS_LOCALE_IS_SPACE(cp) (u_isUWhiteSpace(cp))
+#elif JS_USE_LIBC_LOCALE
+#include <wctype.h>
+#include <ctype.h>
+#define JS_LOCALE_TO_LOWER(cp) ((uint32_t)towlower((wint_t)(cp)))
+#define JS_LOCALE_TO_UPPER(cp) ((uint32_t)towupper((wint_t)(cp)))
+#define JS_LOCALE_IS_SPACE(cp) (iswspace((wint_t)(cp)))
+#else
+static inline uint32_t js_locale_stub_to_lower(uint32_t cp) {
+    if (cp >= 'A' && cp <= 'Z')
+        return cp + 32;
+    return cp;
+}
+static inline uint32_t js_locale_stub_to_upper(uint32_t cp) {
+    if (cp >= 'a' && cp <= 'z')
+        return cp - 32;
+    return cp;
+}
+static inline int js_locale_stub_is_space(uint32_t cp) {
+    switch (cp) {
+    case ' ': case '\t': case '\n': case '\r': case '\f': case '\v':
+        return 1;
+    default:
+        return 0;
+    }
+}
+#define JS_LOCALE_TO_LOWER(cp) js_locale_stub_to_lower(cp)
+#define JS_LOCALE_TO_UPPER(cp) js_locale_stub_to_upper(cp)
+#define JS_LOCALE_IS_SPACE(cp) js_locale_stub_is_space(cp)
+#endif
+
 
 
 size_t jsstr32_head_size() {

--- a/jsstr.c
+++ b/jsstr.c
@@ -1,30 +1,9 @@
 #include <string.h>
 #include <errno.h>
-#include <ctype.h>
-#include <wctype.h>
-
 #include "jsstr.h"
 #include "utf8.h"
 
-static uint32_t locale_libc_to_lower(uint32_t cp) {
-    return (uint32_t)towlower((wint_t)cp);
-}
 
-static uint32_t locale_libc_to_upper(uint32_t cp) {
-    return (uint32_t)towupper((wint_t)cp);
-}
-
-static int locale_libc_is_space(uint32_t cp) {
-    return iswspace((wint_t)cp);
-}
-
-static const js_locale_ops_t locale_libc_ops = {
-    .to_lower = locale_libc_to_lower,
-    .to_upper = locale_libc_to_upper,
-    .is_space = locale_libc_is_space,
-};
-
-const js_locale_ops_t *js_locale_ops = &locale_libc_ops;
 
 size_t jsstr32_head_size() {
     return sizeof(jsstr32_t);
@@ -239,13 +218,13 @@ int jsstr32_concat(jsstr32_t *s, jsstr32_t *src) {
 
 void jsstr32_u32_tolower(jsstr32_t *s) {
     for (size_t i = 0; i < s->len; i++) {
-        s->codepoints[i] = js_locale_ops->to_lower(s->codepoints[i]);
+        s->codepoints[i] = JS_LOCALE_TO_LOWER(s->codepoints[i]);
     }
 }
 
 void jsstr32_u32_toupper(jsstr32_t *s) {
     for (size_t i = 0; i < s->len; i++) {
-        s->codepoints[i] = js_locale_ops->to_upper(s->codepoints[i]);
+        s->codepoints[i] = JS_LOCALE_TO_UPPER(s->codepoints[i]);
     }
 }
 
@@ -297,7 +276,7 @@ void jsstr32_pad_end(jsstr32_t *s, size_t target_len) {
 
 void jsstr32_trim_start(jsstr32_t *s) {
     size_t i = 0;
-    while (i < s->len && js_locale_ops->is_space(s->codepoints[i])) {
+    while (i < s->len && JS_LOCALE_IS_SPACE(s->codepoints[i])) {
         i++;
     }
     if (i > 0) {
@@ -307,7 +286,7 @@ void jsstr32_trim_start(jsstr32_t *s) {
 }
 
 void jsstr32_trim_end(jsstr32_t *s) {
-    while (s->len > 0 && js_locale_ops->is_space(s->codepoints[s->len - 1])) {
+    while (s->len > 0 && JS_LOCALE_IS_SPACE(s->codepoints[s->len - 1])) {
         s->len--;
     }
 }
@@ -763,13 +742,13 @@ int jsstr16_concat(jsstr16_t *s, jsstr16_t *src) {
 
 void jsstr16_u16_tolower(jsstr16_t *s) {
     for (size_t i = 0; i < s->len; i++) {
-        s->codeunits[i] = (uint16_t)js_locale_ops->to_lower(s->codeunits[i]);
+        s->codeunits[i] = (uint16_t)JS_LOCALE_TO_LOWER(s->codeunits[i]);
     }
 }
 
 void jsstr16_u16_toupper(jsstr16_t *s) {
     for (size_t i = 0; i < s->len; i++) {
-        s->codeunits[i] = (uint16_t)js_locale_ops->to_upper(s->codeunits[i]);
+        s->codeunits[i] = (uint16_t)JS_LOCALE_TO_UPPER(s->codeunits[i]);
     }
 }
 
@@ -787,7 +766,7 @@ void jsstr16_u32_tolower(jsstr16_t *s) {
             c = 0xFFFD;
         }
         read += l;
-        c = js_locale_ops->to_lower(c);
+        c = JS_LOCALE_TO_LOWER(c);
         int outlen = UTF16_CLEN(c);
         if (write + outlen > dest_end) {
             break;
@@ -816,7 +795,7 @@ void jsstr16_u32_toupper(jsstr16_t *s) {
             c = 0xFFFD;
         }
         read += l;
-        c = js_locale_ops->to_upper(c);
+        c = JS_LOCALE_TO_UPPER(c);
         int outlen = UTF16_CLEN(c);
         if (write + outlen > dest_end) {
             break;
@@ -879,7 +858,7 @@ void jsstr16_pad_end(jsstr16_t *s, size_t target_len) {
 
 void jsstr16_trim_start(jsstr16_t *s) {
     size_t i = 0;
-    while (i < s->len && js_locale_ops->is_space(s->codeunits[i])) {
+    while (i < s->len && JS_LOCALE_IS_SPACE(s->codeunits[i])) {
         i++;
     }
     if (i > 0) {
@@ -889,7 +868,7 @@ void jsstr16_trim_start(jsstr16_t *s) {
 }
 
 void jsstr16_trim_end(jsstr16_t *s) {
-    while (s->len > 0 && js_locale_ops->is_space(s->codeunits[s->len - 1])) {
+    while (s->len > 0 && JS_LOCALE_IS_SPACE(s->codeunits[s->len - 1])) {
         s->len--;
     }
 }
@@ -1280,13 +1259,13 @@ int jsstr8_concat(jsstr8_t *s, jsstr8_t *src) {
 
 void jsstr8_u8_tolower(jsstr8_t *s) {
     for (size_t i = 0; i < s->len; i++) {
-        s->bytes[i] = (uint8_t)js_locale_ops->to_lower((uint32_t)s->bytes[i]);
+        s->bytes[i] = (uint8_t)JS_LOCALE_TO_LOWER((uint32_t)s->bytes[i]);
     }
 }
 
 void jsstr8_u8_toupper(jsstr8_t *s) {
     for (size_t i = 0; i < s->len; i++) {
-        s->bytes[i] = (uint8_t)js_locale_ops->to_upper((uint32_t)s->bytes[i]);
+        s->bytes[i] = (uint8_t)JS_LOCALE_TO_UPPER((uint32_t)s->bytes[i]);
     }
 }
 
@@ -1304,7 +1283,7 @@ void jsstr8_u32_tolower(jsstr8_t *s) {
             c = 0xFFFD;
         }
         read += l;
-        c = js_locale_ops->to_lower(c);
+        c = JS_LOCALE_TO_LOWER(c);
         const uint32_t *cc = &c;
         UTF8_ENCODE(&cc, &c + 1, &write, dest_end);
     }
@@ -1325,7 +1304,7 @@ void jsstr8_u32_toupper(jsstr8_t *s) {
             c = 0xFFFD;
         }
         read += l;
-        c = js_locale_ops->to_upper(c);
+        c = JS_LOCALE_TO_UPPER(c);
         const uint32_t *cc = &c;
         UTF8_ENCODE(&cc, &c + 1, &write, dest_end);
     }
@@ -1376,7 +1355,7 @@ void jsstr8_pad_end(jsstr8_t *s, size_t target_len) {
 
 void jsstr8_trim_start(jsstr8_t *s) {
     size_t i = 0;
-    while (i < s->len && js_locale_ops->is_space((uint32_t)s->bytes[i])) {
+    while (i < s->len && JS_LOCALE_IS_SPACE((uint32_t)s->bytes[i])) {
         i++;
     }
     if (i > 0) {
@@ -1386,7 +1365,7 @@ void jsstr8_trim_start(jsstr8_t *s) {
 }
 
 void jsstr8_trim_end(jsstr8_t *s) {
-    while (s->len > 0 && js_locale_ops->is_space((uint32_t)s->bytes[s->len - 1])) {
+    while (s->len > 0 && JS_LOCALE_IS_SPACE((uint32_t)s->bytes[s->len - 1])) {
         s->len--;
     }
 }

--- a/jsstr.h
+++ b/jsstr.h
@@ -24,50 +24,7 @@
  */
 #include <stddef.h>
 #include <stdint.h>
-#include <wchar.h>
 #include <sys/types.h>
-
-/*
- * Locale helpers
- *
- * Compile with -DJS_USE_LIBC_LOCALE=0 to disable the libc backed
- * conversions.  In that mode only basic ASCII case conversion and
- * whitespace checks are performed.
- */
-
-#ifndef JS_USE_LIBC_LOCALE
-#define JS_USE_LIBC_LOCALE 1
-#endif
-
-#if JS_USE_LIBC_LOCALE
-#include <wctype.h>
-#include <ctype.h>
-#define JS_LOCALE_TO_LOWER(cp) ((uint32_t)towlower((wint_t)(cp)))
-#define JS_LOCALE_TO_UPPER(cp) ((uint32_t)towupper((wint_t)(cp)))
-#define JS_LOCALE_IS_SPACE(cp) (iswspace((wint_t)(cp)))
-#else
-static inline uint32_t js_locale_stub_to_lower(uint32_t cp) {
-    if (cp >= 'A' && cp <= 'Z')
-        return cp + 32;
-    return cp;
-}
-static inline uint32_t js_locale_stub_to_upper(uint32_t cp) {
-    if (cp >= 'a' && cp <= 'z')
-        return cp - 32;
-    return cp;
-}
-static inline int js_locale_stub_is_space(uint32_t cp) {
-    switch (cp) {
-    case ' ': case '\t': case '\n': case '\r': case '\f': case '\v':
-        return 1;
-    default:
-        return 0;
-    }
-}
-#define JS_LOCALE_TO_LOWER(cp) js_locale_stub_to_lower(cp)
-#define JS_LOCALE_TO_UPPER(cp) js_locale_stub_to_upper(cp)
-#define JS_LOCALE_IS_SPACE(cp) js_locale_stub_is_space(cp)
-#endif
 
 /*
  * JavaScript string of code points

--- a/jsstr.h
+++ b/jsstr.h
@@ -27,6 +27,14 @@
 #include <wchar.h>
 #include <sys/types.h>
 
+typedef struct js_locale_ops_s {
+    uint32_t (*to_lower)(uint32_t cp);
+    uint32_t (*to_upper)(uint32_t cp);
+    int (*is_space)(uint32_t cp);
+} js_locale_ops_t;
+
+extern const js_locale_ops_t *js_locale_ops;
+
 /*
  * JavaScript string of code points
  * A string of unicode characters.

--- a/jsstr.h
+++ b/jsstr.h
@@ -27,13 +27,47 @@
 #include <wchar.h>
 #include <sys/types.h>
 
-typedef struct js_locale_ops_s {
-    uint32_t (*to_lower)(uint32_t cp);
-    uint32_t (*to_upper)(uint32_t cp);
-    int (*is_space)(uint32_t cp);
-} js_locale_ops_t;
+/*
+ * Locale helpers
+ *
+ * Compile with -DJS_USE_LIBC_LOCALE=0 to disable the libc backed
+ * conversions.  In that mode only basic ASCII case conversion and
+ * whitespace checks are performed.
+ */
 
-extern const js_locale_ops_t *js_locale_ops;
+#ifndef JS_USE_LIBC_LOCALE
+#define JS_USE_LIBC_LOCALE 1
+#endif
+
+#if JS_USE_LIBC_LOCALE
+#include <wctype.h>
+#include <ctype.h>
+#define JS_LOCALE_TO_LOWER(cp) ((uint32_t)towlower((wint_t)(cp)))
+#define JS_LOCALE_TO_UPPER(cp) ((uint32_t)towupper((wint_t)(cp)))
+#define JS_LOCALE_IS_SPACE(cp) (iswspace((wint_t)(cp)))
+#else
+static inline uint32_t js_locale_stub_to_lower(uint32_t cp) {
+    if (cp >= 'A' && cp <= 'Z')
+        return cp + 32;
+    return cp;
+}
+static inline uint32_t js_locale_stub_to_upper(uint32_t cp) {
+    if (cp >= 'a' && cp <= 'z')
+        return cp - 32;
+    return cp;
+}
+static inline int js_locale_stub_is_space(uint32_t cp) {
+    switch (cp) {
+    case ' ': case '\t': case '\n': case '\r': case '\f': case '\v':
+        return 1;
+    default:
+        return 0;
+    }
+}
+#define JS_LOCALE_TO_LOWER(cp) js_locale_stub_to_lower(cp)
+#define JS_LOCALE_TO_UPPER(cp) js_locale_stub_to_upper(cp)
+#define JS_LOCALE_IS_SPACE(cp) js_locale_stub_is_space(cp)
+#endif
 
 /*
  * JavaScript string of code points


### PR DESCRIPTION
## Summary
- introduce `js_locale_ops_t` for locale-specific operations
- implement default libc-backed locale functions
- update string operations to use the locale interface

## Testing
- `make test_jsstr`
- `make test_mnurl`
- `make test_utf8`


------
https://chatgpt.com/codex/tasks/task_e_68603e9ab0bc8333950c9d52cccebf68