### PR TITLE
Add full-string normalization & locale compare

### DIFF
--- a/jsstr.c
+++ b/jsstr.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <errno.h>
+#include <stdlib.h>
 #include "jsstr.h"
 #include "utf8.h"
 
@@ -20,15 +21,218 @@
 
 #if JS_USE_ICU_LOCALE
 #include <unicode/uchar.h>
+#include <unicode/unorm2.h>
+#include <unicode/ucol.h>
+#include <unicode/ustring.h>
 #define JS_LOCALE_TO_LOWER(cp) ((uint32_t)u_tolower(cp))
 #define JS_LOCALE_TO_UPPER(cp) ((uint32_t)u_toupper(cp))
 #define JS_LOCALE_IS_SPACE(cp) (u_isUWhiteSpace(cp))
+static inline uint32_t js_locale_icu_normalize_char(uint32_t cp) {
+    UErrorCode status = U_ZERO_ERROR;
+    const UNorm2 *norm = unorm2_getNFCInstance(&status);
+    if (U_FAILURE(status)) return cp;
+    UChar src[4];
+    int32_t len = 0;
+    U16_APPEND_UNSAFE(src, len, cp);
+    UChar dest[4];
+    int32_t dlen = unorm2_normalize(norm, src, len, dest, 4, &status);
+    if (U_FAILURE(status) || dlen <= 0) return cp;
+    UChar32 out;
+    int32_t i = 0;
+    U16_NEXT_UNSAFE(dest, i, out);
+    return (uint32_t)out;
+}
+
+static inline int js_locale_icu_compare_char(uint32_t a, uint32_t b) {
+    UChar sa[4];
+    UChar sb[4];
+    int32_t la = 0;
+    int32_t lb = 0;
+    U16_APPEND_UNSAFE(sa, la, a);
+    U16_APPEND_UNSAFE(sb, lb, b);
+    UErrorCode status = U_ZERO_ERROR;
+    UCollator *coll = ucol_open("", &status);
+    if (U_FAILURE(status)) {
+        return (int)(a - b);
+    }
+    int result = ucol_strcoll(coll, sa, la, sb, lb);
+    ucol_close(coll);
+    return result;
+}
+#define JS_LOCALE_NORMALIZE(cp) js_locale_icu_normalize_char(cp)
+#define JS_LOCALE_COMPARE(a,b) js_locale_icu_compare_char(a,b)
+
+static inline int32_t js_locale_icu_normalize_u16(UChar *buf, int32_t len, int32_t cap) {
+    UErrorCode status = U_ZERO_ERROR;
+    const UNorm2 *norm = unorm2_getNFCInstance(&status);
+    if (U_FAILURE(status)) return len;
+    UChar *tmp = (UChar *)malloc(sizeof(UChar) * cap);
+    if (!tmp) return len;
+    int32_t out = unorm2_normalize(norm, buf, len, tmp, cap, &status);
+    if (U_FAILURE(status)) {
+        free(tmp);
+        return len;
+    }
+    memcpy(buf, tmp, out * sizeof(UChar));
+    free(tmp);
+    return out;
+}
+
+static inline int js_locale_icu_compare_u16(const UChar *a, int32_t la, const UChar *b, int32_t lb) {
+    UErrorCode status = U_ZERO_ERROR;
+    UCollator *coll = ucol_open("", &status);
+    if (U_FAILURE(status)) return 0;
+    int r = ucol_strcoll(coll, a, la, b, lb);
+    ucol_close(coll);
+    return r;
+}
+
+static inline int32_t js_locale_icu_normalize_u32(uint32_t *buf, int32_t len, int32_t cap) {
+    UChar *tmp = (UChar *)malloc(sizeof(UChar) * cap * 2);
+    if (!tmp)
+        return len;
+    int32_t off = 0;
+    for (int32_t i = 0; i < len; i++) {
+        U16_APPEND_UNSAFE(tmp, off, buf[i]);
+    }
+    int32_t out_len = js_locale_icu_normalize_u16(tmp, off, cap * 2);
+    int32_t pos = 0;
+    int32_t out_cp = 0;
+    while (pos < out_len && out_cp < cap) {
+        UChar32 c;
+        U16_NEXT_UNSAFE(tmp, pos, c);
+        buf[out_cp++] = (uint32_t)c;
+    }
+    free(tmp);
+    return out_cp;
+}
+
+static inline int js_locale_icu_compare_u32(const uint32_t *a, int32_t la, const uint32_t *b, int32_t lb) {
+    UChar *ua = (UChar *)malloc(sizeof(UChar) * la * 2);
+    UChar *ub = (UChar *)malloc(sizeof(UChar) * lb * 2);
+    if (!ua || !ub) {
+        free(ua);
+        free(ub);
+        return 0;
+    }
+    int32_t la16 = 0, lb16 = 0;
+    for (int32_t i = 0; i < la; i++)
+        U16_APPEND_UNSAFE(ua, la16, a[i]);
+    for (int32_t i = 0; i < lb; i++)
+        U16_APPEND_UNSAFE(ub, lb16, b[i]);
+    int r = js_locale_icu_compare_u16(ua, la16, ub, lb16);
+    free(ua);
+    free(ub);
+    return r;
+}
+
+static inline int32_t js_locale_icu_normalize_u8(uint8_t *buf, int32_t len, int32_t cap) {
+    UChar *tmp = (UChar *)malloc(sizeof(UChar) * cap * 2);
+    if (!tmp)
+        return len;
+    int32_t u16len = 0;
+    for (int32_t i = 0; i < len;) {
+        uint32_t c;
+        int l;
+        UTF8_CHAR((const char *)buf + i, (const char *)buf + len, &c, &l);
+        U16_APPEND_UNSAFE(tmp, u16len, c);
+        i += l;
+    }
+    int32_t out_len = js_locale_icu_normalize_u16(tmp, u16len, cap * 2);
+    uint8_t *write = buf;
+    uint8_t *end = buf + cap;
+    int32_t pos = 0;
+    while (pos < out_len && write < end) {
+        UChar32 c;
+        U16_NEXT_UNSAFE(tmp, pos, c);
+        const uint32_t *cc = (const uint32_t *)&c;
+        UTF8_ENCODE(&cc, &c + 1, &write, end);
+    }
+    free(tmp);
+    return (int32_t)(write - buf);
+}
+
+static inline int js_locale_icu_compare_u8(const uint8_t *a, int32_t la, const uint8_t *b, int32_t lb) {
+    UChar *ua = (UChar *)malloc(sizeof(UChar) * la * 2);
+    UChar *ub = (UChar *)malloc(sizeof(UChar) * lb * 2);
+    if (!ua || !ub) {
+        free(ua);
+        free(ub);
+        return 0;
+    }
+    int32_t la16 = 0, lb16 = 0;
+    for (int32_t i = 0; i < la;) {
+        uint32_t c; int l; UTF8_CHAR((const char *)a + i, (const char *)a + la, &c, &l); i += l; U16_APPEND_UNSAFE(ua, la16, c);
+    }
+    for (int32_t i = 0; i < lb;) {
+        uint32_t c; int l; UTF8_CHAR((const char *)b + i, (const char *)b + lb, &c, &l); i += l; U16_APPEND_UNSAFE(ub, lb16, c);
+    }
+    int r = js_locale_icu_compare_u16(ua, la16, ub, lb16);
+    free(ua);
+    free(ub);
+    return r;
+}
+#define JS_LOCALE_NORMALIZE_U32 js_locale_icu_normalize_u32
+#define JS_LOCALE_COMPARE_U32  js_locale_icu_compare_u32
+#define JS_LOCALE_NORMALIZE_U16 js_locale_icu_normalize_u16
+#define JS_LOCALE_COMPARE_U16  js_locale_icu_compare_u16
+#define JS_LOCALE_NORMALIZE_U8  js_locale_icu_normalize_u8
+#define JS_LOCALE_COMPARE_U8    js_locale_icu_compare_u8
 #elif JS_USE_LIBC_LOCALE
 #include <wctype.h>
 #include <ctype.h>
+#include <wchar.h>
 #define JS_LOCALE_TO_LOWER(cp) ((uint32_t)towlower((wint_t)(cp)))
 #define JS_LOCALE_TO_UPPER(cp) ((uint32_t)towupper((wint_t)(cp)))
 #define JS_LOCALE_IS_SPACE(cp) (iswspace((wint_t)(cp)))
+static inline uint32_t js_locale_libc_normalize(uint32_t cp) {
+    return cp; /* no normalization API in libc */
+}
+static inline int js_locale_libc_compare(uint32_t a, uint32_t b) {
+    wchar_t sa[2] = {(wchar_t)a, L'\0'};
+    wchar_t sb[2] = {(wchar_t)b, L'\0'};
+    return wcscoll(sa, sb);
+}
+#define JS_LOCALE_NORMALIZE(cp) js_locale_libc_normalize(cp)
+#define JS_LOCALE_COMPARE(a,b) js_locale_libc_compare(a,b)
+
+static inline int32_t js_locale_libc_normalize_u32(uint32_t *buf, int32_t len, int32_t cap) {
+    (void)buf; (void)cap; return len;
+}
+static inline int32_t js_locale_libc_normalize_u16(uint16_t *buf, int32_t len, int32_t cap) {
+    (void)buf; (void)cap; return len;
+}
+static inline int32_t js_locale_libc_normalize_u8(uint8_t *buf, int32_t len, int32_t cap) {
+    (void)buf; (void)cap; return len;
+}
+
+static inline int js_locale_libc_compare_u16(const uint16_t *a, int32_t la, const uint16_t *b, int32_t lb) {
+    wchar_t *wa = (wchar_t *)malloc(sizeof(wchar_t) * (la + 1));
+    wchar_t *wb = (wchar_t *)malloc(sizeof(wchar_t) * (lb + 1));
+    if (!wa || !wb) { free(wa); free(wb); return 0; }
+    for (int32_t i = 0; i < la; i++) wa[i] = (wchar_t)a[i];
+    wa[la] = L'\0';
+    for (int32_t i = 0; i < lb; i++) wb[i] = (wchar_t)b[i];
+    wb[lb] = L'\0';
+    int r = wcscoll(wa, wb);
+    free(wa); free(wb);
+    return r;
+}
+
+static inline int js_locale_libc_compare_u32(const uint32_t *a, int32_t la, const uint32_t *b, int32_t lb) {
+    return js_locale_libc_compare_u16((const uint16_t *)a, la, (const uint16_t *)b, lb);
+}
+
+static inline int js_locale_libc_compare_u8(const uint8_t *a, int32_t la, const uint8_t *b, int32_t lb) {
+    return js_locale_libc_compare_u16((const uint16_t *)a, la, (const uint16_t *)b, lb);
+}
+
+#define JS_LOCALE_NORMALIZE_U32 js_locale_libc_normalize_u32
+#define JS_LOCALE_COMPARE_U32  js_locale_libc_compare_u32
+#define JS_LOCALE_NORMALIZE_U16 js_locale_libc_normalize_u16
+#define JS_LOCALE_COMPARE_U16  js_locale_libc_compare_u16
+#define JS_LOCALE_NORMALIZE_U8  js_locale_libc_normalize_u8
+#define JS_LOCALE_COMPARE_U8    js_locale_libc_compare_u8
 #else
 static inline uint32_t js_locale_stub_to_lower(uint32_t cp) {
     if (cp >= 'A' && cp <= 'Z')
@@ -51,6 +255,41 @@ static inline int js_locale_stub_is_space(uint32_t cp) {
 #define JS_LOCALE_TO_LOWER(cp) js_locale_stub_to_lower(cp)
 #define JS_LOCALE_TO_UPPER(cp) js_locale_stub_to_upper(cp)
 #define JS_LOCALE_IS_SPACE(cp) js_locale_stub_is_space(cp)
+#define JS_LOCALE_NORMALIZE(cp) (cp)
+#define JS_LOCALE_COMPARE(a,b) ((int)((a)-(b)))
+
+static inline int32_t js_locale_stub_normalize_u32(uint32_t *buf, int32_t len, int32_t cap) {
+    (void)cap;
+    for (int32_t i = 0; i < len; i++) buf[i] = JS_LOCALE_NORMALIZE(buf[i]);
+    return len;
+}
+static inline int32_t js_locale_stub_normalize_u16(uint16_t *buf, int32_t len, int32_t cap) {
+    (void)cap; for (int32_t i=0;i<len;i++) buf[i]=JS_LOCALE_NORMALIZE(buf[i]); return len;
+}
+static inline int32_t js_locale_stub_normalize_u8(uint8_t *buf, int32_t len, int32_t cap) {
+    (void)cap; for (int32_t i=0;i<len;i++) buf[i]=JS_LOCALE_NORMALIZE(buf[i]); return len;
+}
+
+static inline int js_locale_stub_compare_u32(const uint32_t *a, int32_t la, const uint32_t *b, int32_t lb) {
+    int32_t l = la < lb ? la : lb;
+    for (int32_t i=0;i<l;i++) if (a[i]!=b[i]) return (int)(a[i]-b[i]);
+    return la - lb;
+}
+static inline int js_locale_stub_compare_u16(const uint16_t *a, int32_t la, const uint16_t *b, int32_t lb) {
+    return js_locale_stub_compare_u32((const uint32_t *)a, la, (const uint32_t *)b, lb);
+}
+static inline int js_locale_stub_compare_u8(const uint8_t *a, int32_t la, const uint8_t *b, int32_t lb) {
+    int32_t l = la < lb ? la : lb;
+    for (int32_t i=0;i<l;i++) if (a[i]!=b[i]) return (int)((int)a[i]-(int)b[i]);
+    return la - lb;
+}
+
+#define JS_LOCALE_NORMALIZE_U32 js_locale_stub_normalize_u32
+#define JS_LOCALE_COMPARE_U32  js_locale_stub_compare_u32
+#define JS_LOCALE_NORMALIZE_U16 js_locale_stub_normalize_u16
+#define JS_LOCALE_COMPARE_U16  js_locale_stub_compare_u16
+#define JS_LOCALE_NORMALIZE_U8  js_locale_stub_normalize_u8
+#define JS_LOCALE_COMPARE_U8    js_locale_stub_compare_u8
 #endif
 
 
@@ -276,6 +515,15 @@ void jsstr32_u32_toupper(jsstr32_t *s) {
     for (size_t i = 0; i < s->len; i++) {
         s->codepoints[i] = JS_LOCALE_TO_UPPER(s->codepoints[i]);
     }
+}
+
+void jsstr32_u32_normalize(jsstr32_t *s) {
+    s->len = JS_LOCALE_NORMALIZE_U32(s->codepoints, (int32_t)s->len, (int32_t)s->cap);
+}
+
+int jsstr32_u32_locale_compare(jsstr32_t *s1, jsstr32_t *s2) {
+    return JS_LOCALE_COMPARE_U32(s1->codepoints, (int32_t)s1->len,
+                                 s2->codepoints, (int32_t)s2->len);
 }
 
 int jsstr32_repeat(jsstr32_t *dest, jsstr32_t *src, size_t count) {
@@ -802,6 +1050,15 @@ void jsstr16_u16_toupper(jsstr16_t *s) {
     }
 }
 
+void jsstr16_u16_normalize(jsstr16_t *s) {
+    s->len = JS_LOCALE_NORMALIZE_U16(s->codeunits, (int32_t)s->len, (int32_t)s->cap);
+}
+
+int jsstr16_u16_locale_compare(jsstr16_t *s1, jsstr16_t *s2) {
+    return JS_LOCALE_COMPARE_U16(s1->codeunits, (int32_t)s1->len,
+                                 s2->codeunits, (int32_t)s2->len);
+}
+
 void jsstr16_u32_tolower(jsstr16_t *s) {
     uint16_t *read = s->codeunits;
     uint16_t *write = s->codeunits;
@@ -858,6 +1115,15 @@ void jsstr16_u32_toupper(jsstr16_t *s) {
         }
     }
     s->len = write - s->codeunits;
+}
+
+void jsstr16_u32_normalize(jsstr16_t *s) {
+    s->len = JS_LOCALE_NORMALIZE_U16(s->codeunits, (int32_t)s->len, (int32_t)s->cap);
+}
+
+int jsstr16_u32_locale_compare(jsstr16_t *s1, jsstr16_t *s2) {
+    return JS_LOCALE_COMPARE_U16(s1->codeunits, (int32_t)s1->len,
+                                 s2->codeunits, (int32_t)s2->len);
 }
 
 int jsstr16_repeat(jsstr16_t *dest, jsstr16_t *src, size_t count) {
@@ -1359,6 +1625,24 @@ void jsstr8_u32_toupper(jsstr8_t *s) {
         UTF8_ENCODE(&cc, &c + 1, &write, dest_end);
     }
     s->len = write - s->bytes;
+}
+
+void jsstr8_u8_normalize(jsstr8_t *s) {
+    s->len = JS_LOCALE_NORMALIZE_U8(s->bytes, (int32_t)s->len, (int32_t)s->cap);
+}
+
+void jsstr8_u32_normalize(jsstr8_t *s) {
+    s->len = JS_LOCALE_NORMALIZE_U8(s->bytes, (int32_t)s->len, (int32_t)s->cap);
+}
+
+int jsstr8_u8_locale_compare(jsstr8_t *s1, jsstr8_t *s2) {
+    return JS_LOCALE_COMPARE_U8(s1->bytes, (int32_t)s1->len,
+                                s2->bytes, (int32_t)s2->len);
+}
+
+int jsstr8_u32_locale_compare(jsstr8_t *s1, jsstr8_t *s2) {
+    return JS_LOCALE_COMPARE_U8(s1->bytes, (int32_t)s1->len,
+                                s2->bytes, (int32_t)s2->len);
 }
 
 int jsstr8_repeat(jsstr8_t *dest, jsstr8_t *src, size_t count) {

--- a/jsstr.h
+++ b/jsstr.h
@@ -169,6 +169,8 @@ ssize_t jsstr32_u32_indextoken(jsstr32_t *s, uint32_t *search_c, size_t search_c
 int jsstr32_concat(jsstr32_t *s, jsstr32_t *src);
 void jsstr32_u32_tolower(jsstr32_t *s);
 void jsstr32_u32_toupper(jsstr32_t *s);
+void jsstr32_u32_normalize(jsstr32_t *s);
+int jsstr32_u32_locale_compare(jsstr32_t *s1, jsstr32_t *s2);
 int jsstr32_repeat(jsstr32_t *dest, jsstr32_t *src, size_t count);
 void jsstr32_pad_start(jsstr32_t *s, size_t target_len);
 void jsstr32_pad_end(jsstr32_t *s, size_t target_len);
@@ -230,8 +232,12 @@ ssize_t jsstr16_u32_indextoken(jsstr16_t *s, uint32_t *search_c, size_t search_c
 int jsstr16_concat(jsstr16_t *s, jsstr16_t *src);
 void jsstr16_u16_tolower(jsstr16_t *s);
 void jsstr16_u16_toupper(jsstr16_t *s);
+void jsstr16_u16_normalize(jsstr16_t *s);
+int jsstr16_u16_locale_compare(jsstr16_t *s1, jsstr16_t *s2);
 void jsstr16_u32_tolower(jsstr16_t *s);
 void jsstr16_u32_toupper(jsstr16_t *s);
+void jsstr16_u32_normalize(jsstr16_t *s);
+int jsstr16_u32_locale_compare(jsstr16_t *s1, jsstr16_t *s2);
 int jsstr16_repeat(jsstr16_t *dest, jsstr16_t *src, size_t count);
 void jsstr16_pad_start(jsstr16_t *s, size_t target_len);
 void jsstr16_pad_end(jsstr16_t *s, size_t target_len);
@@ -293,8 +299,12 @@ ssize_t jsstr8_u32_indextoken(jsstr8_t *s, uint32_t *search_c, size_t search_c_l
 int jsstr8_concat(jsstr8_t *s, jsstr8_t *src);
 void jsstr8_u8_tolower(jsstr8_t *s);
 void jsstr8_u8_toupper(jsstr8_t *s);
+void jsstr8_u8_normalize(jsstr8_t *s);
+int jsstr8_u8_locale_compare(jsstr8_t *s1, jsstr8_t *s2);
 void jsstr8_u32_tolower(jsstr8_t *s);
 void jsstr8_u32_toupper(jsstr8_t *s);
+void jsstr8_u32_normalize(jsstr8_t *s);
+int jsstr8_u32_locale_compare(jsstr8_t *s1, jsstr8_t *s2);
 int jsstr8_repeat(jsstr8_t *dest, jsstr8_t *src, size_t count);
 void jsstr8_pad_start(jsstr8_t *s, size_t target_len);
 void jsstr8_pad_end(jsstr8_t *s, size_t target_len);

--- a/test_jsstr.c
+++ b/test_jsstr.c
@@ -81,6 +81,7 @@ void test_jsstr32_lifecycle() {
     jsstr32_t s_cmp;
     jsstr32_init_from_str(&s_cmp, L"Hello, World!");
     printf("jsstr32_u32_cmp: %d\n", jsstr32_u32_cmp(&s, &s_cmp));
+    printf("jsstr32_u32_locale_compare: %d\n", jsstr32_u32_locale_compare(&s, &s_cmp));
 
     uint32_t search_c = L'o';
     size_t start_i = 6;
@@ -107,6 +108,8 @@ void test_jsstr32_lifecycle() {
     printf("jsstr32_toupper: %lc%lc%lc\n", s.codepoints[0], s.codepoints[1], s.codepoints[2]);
     jsstr32_u32_tolower(&s);
     printf("jsstr32_tolower: %lc%lc%lc\n", s.codepoints[0], s.codepoints[1], s.codepoints[2]);
+    jsstr32_u32_normalize(&s);
+    printf("jsstr32_u32_normalize: %lc%lc%lc\n", s.codepoints[0], s.codepoints[1], s.codepoints[2]);
     jsstr32_init_from_buf(&dest, (char *)dest_buf, dest_len);
     jsstr32_repeat(&dest, &s, 3);
     printf("jsstr32_repeat len: %zu\n", jsstr32_get_utf32len(&dest));
@@ -204,6 +207,7 @@ void test_jsstr16_lifecycle() {
     /* test cmp */
     jsstr16_init_from_str(&s_cmp, utf16_str);
     printf("jsstr16_u16_cmp: %d\n", jsstr16_u16_cmp(&s_str, &s_cmp));
+    printf("jsstr16_u16_locale_compare: %d\n", jsstr16_u16_locale_compare(&s_str, &s_cmp));
 
     /* test indexof */
     uint32_t search_c = L'o';
@@ -245,6 +249,7 @@ void test_jsstr16_lifecycle() {
     /* test cmp */
     jsstr16_init_from_str(&s_cmp, utf16_str);
     printf("jsstr16_u32_cmp: %d\n", jsstr16_u32_cmp(&s_str, &s_cmp));
+    printf("jsstr16_u32_locale_compare: %d\n", jsstr16_u32_locale_compare(&s_str, &s_cmp));
 
     jsstr16_t prefix;
     jsstr16_t suffix;
@@ -265,10 +270,14 @@ void test_jsstr16_lifecycle() {
     printf("jsstr16_u32_toupper: %04x %04x %04x\n", s.codeunits[0], s.codeunits[1], s.codeunits[2]);
     jsstr16_u32_tolower(&s);
     printf("jsstr16_u32_tolower: %04x %04x %04x\n", s.codeunits[0], s.codeunits[1], s.codeunits[2]);
+    jsstr16_u32_normalize(&s);
+    printf("jsstr16_u32_normalize: %04x %04x %04x\n", s.codeunits[0], s.codeunits[1], s.codeunits[2]);
     jsstr16_u16_toupper(&s);
     printf("jsstr16_u16_toupper: %04x %04x %04x\n", s.codeunits[0], s.codeunits[1], s.codeunits[2]);
     jsstr16_u16_tolower(&s);
     printf("jsstr16_u16_tolower: %04x %04x %04x\n", s.codeunits[0], s.codeunits[1], s.codeunits[2]);
+    jsstr16_u16_normalize(&s);
+    printf("jsstr16_u16_normalize: %04x %04x %04x\n", s.codeunits[0], s.codeunits[1], s.codeunits[2]);
     jsstr16_init_from_buf(&dest16, (char *)dest16_buf, dest16_len);
     jsstr16_repeat(&dest16, &s, 3);
     printf("jsstr16_repeat len: %zu\n", jsstr16_get_utf16len(&dest16));
@@ -365,6 +374,7 @@ void test_jsstr8_lifecycle() {
 
     jsstr8_init_from_str(&s_cmp, "Hello, World!");
     printf("jsstr8_u8_cmp: %d\n", jsstr8_u8_cmp(&s_str, &s_cmp));
+    printf("jsstr8_u8_locale_compare: %d\n", jsstr8_u8_locale_compare(&s_str, &s_cmp));
 
     uint32_t search_c = L'o';
     size_t start_i = 6;
@@ -402,6 +412,7 @@ void test_jsstr8_lifecycle() {
     /* test cmp */
     jsstr8_init_from_str(&s_cmp, "Hello, World!");
     printf("jsstr8_u32_cmp: %d\n", jsstr8_u32_cmp(&s_str, &s_cmp));
+    printf("jsstr8_u32_locale_compare: %d\n", jsstr8_u32_locale_compare(&s_str, &s_cmp));
 
     jsstr8_t prefix;
     jsstr8_t suffix;
@@ -419,10 +430,14 @@ void test_jsstr8_lifecycle() {
     printf("jsstr8_u8_toupper: %c%c%c\n", s.bytes[0], s.bytes[1], s.bytes[2]);
     jsstr8_u8_tolower(&s);
     printf("jsstr8_u8_tolower: %c%c%c\n", s.bytes[0], s.bytes[1], s.bytes[2]);
+    jsstr8_u8_normalize(&s);
+    printf("jsstr8_u8_normalize: %c%c%c\n", s.bytes[0], s.bytes[1], s.bytes[2]);
     jsstr8_u32_toupper(&s);
     printf("jsstr8_u32_toupper: %c%c%c\n", s.bytes[0], s.bytes[1], s.bytes[2]);
     jsstr8_u32_tolower(&s);
     printf("jsstr8_u32_tolower: %c%c%c\n", s.bytes[0], s.bytes[1], s.bytes[2]);
+    jsstr8_u32_normalize(&s);
+    printf("jsstr8_u32_normalize: %c%c%c\n", s.bytes[0], s.bytes[1], s.bytes[2]);
     jsstr8_init_from_buf(&dest8, (char *)dest8_buf, dest8_len);
     jsstr8_repeat(&dest8, &s, 3);
     printf("jsstr8_repeat len: %zu\n", jsstr8_get_utf8len(&dest8));


### PR DESCRIPTION
## Summary
- refine ICU helpers and add buffer-level ICU normalization/compare
- update normalize and compare APIs to use whole-string operations
- implement per-format locale helpers for UTF-8/16/32 strings

## Testing
- `make test_jsstr`

------
https://chatgpt.com/codex/tasks/task_e_68607deeb2188333a60532b9ca4a8068