### PR TITLE
Add Unicode database generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,11 @@ UnicodeData.txt:
 unicode_case_data.h: UnicodeData.txt scripts/gen_unicode_case.py
 	python3 scripts/gen_unicode_case.py UnicodeData.txt unicode_case_data.h
 
-test_unicode: test_unicode.c unicode.c unicode_case_data.h
+unicode_db.h: UnicodeData.txt scripts/gen_unicode_db.py
+	python3 scripts/gen_unicode_db.py UnicodeData.txt unicode_db.h
+
+
+test_unicode: test_unicode.c unicode.c unicode_case_data.h unicode_db.h
 	$(CC) -g $(CFLAGS) $(LDFLAGS) $^ -o $@
 	./$@
 

--- a/scripts/gen_unicode_db.py
+++ b/scripts/gen_unicode_db.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+import sys
+
+MAX_FIELDS = 15
+
+
+def compute_max_lengths(path):
+    max_len = [0]*MAX_FIELDS
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            fields = line.rstrip('\n').split(';')
+            for i, field in enumerate(fields):
+                if len(field) > max_len[i]:
+                    max_len[i] = len(field)
+    return max_len
+
+
+def parse_records(path):
+    records = []
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            fields = line.split(';')
+            if len(fields) < MAX_FIELDS:
+                fields += [''] * (MAX_FIELDS - len(fields))
+            code = int(fields[0], 16)
+            records.append((code,) + tuple(fields[1:]))
+    return records
+
+
+def emit(records, max_len, out):
+    out.write('#ifndef UNICODE_DB_H\n')
+    out.write('#define UNICODE_DB_H\n')
+    out.write('#include <stdint.h>\n')
+    out.write('#include <stddef.h>\n')
+    out.write('/* maximum field lengths including null terminator */\n')
+    macros = [
+        ("UNICODE_NAME_MAX", max_len[1] + 1),
+        ("UNICODE_GC_MAX", max_len[2] + 1),
+        ("UNICODE_CC_MAX", max_len[3] + 1),
+        ("UNICODE_BIDI_MAX", max_len[4] + 1),
+        ("UNICODE_DECOMP_MAX", max_len[5] + 1),
+        ("UNICODE_DECIMAL_MAX", max_len[6] + 1),
+        ("UNICODE_DIGIT_MAX", max_len[7] + 1),
+        ("UNICODE_NUMERIC_MAX", max_len[8] + 1),
+        ("UNICODE_MIRRORED_MAX", max_len[9] + 1),
+        ("UNICODE_UNICODE1_NAME_MAX", max_len[10] + 1),
+        ("UNICODE_ISO_COMMENT_MAX", max_len[11] + 1),
+        ("UNICODE_SIMPLE_UPPER_MAX", max_len[12] + 1),
+        ("UNICODE_SIMPLE_LOWER_MAX", max_len[13] + 1),
+        ("UNICODE_SIMPLE_TITLE_MAX", max_len[14] + 1),
+    ]
+    for name, val in macros:
+        out.write(f'#define {name} {val}\n')
+    out.write('typedef struct {\n')
+    out.write('    uint32_t code;\n')
+    out.write('    char name[UNICODE_NAME_MAX];\n')
+    out.write('    char general_category[UNICODE_GC_MAX];\n')
+    out.write('    char combining_class[UNICODE_CC_MAX];\n')
+    out.write('    char bidi_class[UNICODE_BIDI_MAX];\n')
+    out.write('    char decomposition[UNICODE_DECOMP_MAX];\n')
+    out.write('    char decimal_value[UNICODE_DECIMAL_MAX];\n')
+    out.write('    char digit_value[UNICODE_DIGIT_MAX];\n')
+    out.write('    char numeric_value[UNICODE_NUMERIC_MAX];\n')
+    out.write('    char mirrored[UNICODE_MIRRORED_MAX];\n')
+    out.write('    char unicode1_name[UNICODE_UNICODE1_NAME_MAX];\n')
+    out.write('    char iso_comment[UNICODE_ISO_COMMENT_MAX];\n')
+    out.write('    char simple_upper[UNICODE_SIMPLE_UPPER_MAX];\n')
+    out.write('    char simple_lower[UNICODE_SIMPLE_LOWER_MAX];\n')
+    out.write('    char simple_title[UNICODE_SIMPLE_TITLE_MAX];\n')
+    out.write('} unicode_record_t;\n')
+    out.write('static const unicode_record_t unicode_db[] = {\n')
+    for rec in records:
+        fields = []
+        for field in rec[1:]:
+            esc = field.replace('\\', '\\\\').replace('"', '\\"')
+            fields.append(f'"{esc}"')
+        out.write(f'    {{0x{rec[0]:04X}, ' + ', '.join(fields) + '},\n')
+    out.write('};\n')
+    out.write('static const size_t unicode_db_len = sizeof(unicode_db)/sizeof(unicode_db[0]);\n')
+    out.write('#endif /* UNICODE_DB_H */\n')
+
+
+def main(argv):
+    if len(argv) != 3:
+        print('usage: gen_unicode_db.py UnicodeData.txt output.h')
+        return 1
+    path_in = argv[1]
+    path_out = argv[2]
+    max_len = compute_max_lengths(path_in)
+    records = parse_records(path_in)
+    with open(path_out, 'w', encoding='utf-8') as out:
+        emit(records, max_len, out)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add `gen_unicode_db.py` to generate a static array of UnicodeData
- generate `unicode_db.h` using the new script
- update `Makefile` to include rules for the new header

## Testing
- `make test_unicode`

------
https://chatgpt.com/codex/tasks/task_e_68617e2590548333950a6c024a76aa94