### PR TITLE
Use unicode for stub case conversion

### DIFF
--- a/jsstr.c
+++ b/jsstr.c
@@ -234,15 +234,13 @@ static inline int js_locale_libc_compare_u8(const uint8_t *a, int32_t la, const 
 #define JS_LOCALE_NORMALIZE_U8  js_locale_libc_normalize_u8
 #define JS_LOCALE_COMPARE_U8    js_locale_libc_compare_u8
 #else
+#include "unicode.h"
+
 static inline uint32_t js_locale_stub_to_lower(uint32_t cp) {
-    if (cp >= 'A' && cp <= 'Z')
-        return cp + 32;
-    return cp;
+    return unicode_tolower(cp);
 }
 static inline uint32_t js_locale_stub_to_upper(uint32_t cp) {
-    if (cp >= 'a' && cp <= 'z')
-        return cp - 32;
-    return cp;
+    return unicode_toupper(cp);
 }
 static inline int js_locale_stub_is_space(uint32_t cp) {
     switch (cp) {


### PR DESCRIPTION
## Summary
- include `unicode.h` in `jsstr.c` when building without libc/ICU locale
- replace ASCII-only case conversion with calls to `unicode_tolower` and `unicode_toupper`

## Testing
- `make test_jsstr`
- `make test_mnurl`
- `make test_unicode`
- `make test_utf8`
- `gcc -g -DJS_USE_LIBC_LOCALE=0 -DJS_USE_ICU_LOCALE=0 test_jsstr.c jsstr.c unicode.c -o test_jsstr_stub && ./test_jsstr_stub | head`

------
https://chatgpt.com/codex/tasks/task_e_68619841b9f083339f4d728132eb7f27