### PR TITLE
Fix linking for locale stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,11 @@ simple_example: example/simple.o libjsmn.a
 jsondump: example/jsondump.o libjsmn.a
 	$(CC) $(LDFLAGS) $^ -o $@
 
-test_jsstr: test_jsstr.c jsstr.c
+test_jsstr: test_jsstr.c jsstr.c unicode.c
 	$(CC) -g $(CFLAGS) $(LDFLAGS) $^ -o $@
 	./$@
 
-test_mnurl: test_mnurl.c mnurl.c jsstr.c
+test_mnurl: test_mnurl.c mnurl.c jsstr.c unicode.c
 	$(CC) -g $(CFLAGS) $(LDFLAGS) $^ -o $@
 	./$@
 


### PR DESCRIPTION
## Summary
- link unicode.c when building jsstr and mnurl tests

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68619ae6876083339400c1da949ad23a