### PR TITLE
Add unicode normalization lookup APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ DerivedNormalizationProps.txt:
 unicode_derived_normalization_props.h: DerivedNormalizationProps.txt scripts/gen_unicode_derived_normalization_props.py
 	python3 scripts/gen_unicode_derived_normalization_props.py DerivedNormalizationProps.txt unicode_derived_normalization_props.h
 
-test_unicode: test_unicode.c unicode.c unicode_case_data.h unicode_db.h
+test_unicode: test_unicode.c unicode.c unicode_case_data.h unicode_db.h unicode_exclusions.h unicode_derived_normalization_props.h
 	$(CC) -g $(CFLAGS) $(LDFLAGS) $^ -o $@
 	./$@
 

--- a/test_unicode.c
+++ b/test_unicode.c
@@ -12,7 +12,29 @@ static void test_case_conversion() {
     printf("P->%c g->%c\n", (char)p, (char)g);
 }
 
+static void test_exclusions() {
+    printf("0958 excluded: %d\n", unicode_is_composition_exclusion(0x0958));
+    printf("0041 excluded: %d\n", unicode_is_composition_exclusion(0x0041));
+}
+
+static void test_qc() {
+    printf("NFD_QC 00C0: %d\n", unicode_get_nfd_qc(0x00C0));
+    printf("NFC_QC 0341: %d\n", unicode_get_nfc_qc(0x0341));
+    printf("NFC_QC 0041: %d\n", unicode_get_nfc_qc(0x0041));
+}
+
+static void test_nfkc_maps() {
+    uint32_t buf[UNICODE_NFKC_CF_MAX];
+    size_t len = unicode_nfkc_cf(0x00A8, buf);
+    printf("NFKC_CF 00A8 len %zu first %04X\n", len, buf[0]);
+    len = unicode_nfkc_scf(0x00A8, buf);
+    printf("NFKC_SCF 00A8 len %zu first %04X\n", len, buf[0]);
+}
+
 int main() {
     test_case_conversion();
+    test_exclusions();
+    test_qc();
+    test_nfkc_maps();
     return 0;
 }

--- a/unicode.c
+++ b/unicode.c
@@ -3,6 +3,8 @@
 #include "unicode_db.h"
 #include "unicode_collation.h"
 #include "unicode_special_casing.h"
+#include "unicode_exclusions.h"
+#include "unicode_derived_normalization_props.h"
 
 static int unicode_find_index(uint32_t cp, size_t *index) {
     size_t left = 0;
@@ -148,4 +150,124 @@ int unicode_collation_lookup(uint32_t cp, uint16_t *primary, uint16_t *secondary
         return 1;
     }
     return 0;
+}
+
+static int unicode_uint32_list_contains(const uint32_t *arr, size_t len, uint32_t cp) {
+    size_t left = 0;
+    size_t right = len;
+    while (left < right) {
+        size_t mid = left + (right - left) / 2;
+        if (arr[mid] == cp)
+            return 1;
+        if (cp < arr[mid])
+            right = mid;
+        else
+            left = mid + 1;
+    }
+    return 0;
+}
+
+static int unicode_qc_lookup(const unicode_qc_range_t *ranges, size_t len, uint32_t cp) {
+    size_t left = 0;
+    size_t right = len;
+    while (left < right) {
+        size_t mid = left + (right - left) / 2;
+        if (cp < ranges[mid].start) {
+            right = mid;
+        } else if (cp > ranges[mid].end) {
+            left = mid + 1;
+        } else {
+            return ranges[mid].qc;
+        }
+    }
+    return UNICODE_QC_YES;
+}
+
+static int unicode_range_contains(const unicode_range_t *ranges, size_t len, uint32_t cp) {
+    size_t left = 0;
+    size_t right = len;
+    while (left < right) {
+        size_t mid = left + (right - left) / 2;
+        if (cp < ranges[mid].start) {
+            right = mid;
+        } else if (cp > ranges[mid].end) {
+            left = mid + 1;
+        } else {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int unicode_nfkc_cf_find(uint32_t cp, size_t *index, uint8_t *len) {
+    size_t left = 0;
+    size_t right = unicode_nfkc_cf_map_len;
+    while (left < right) {
+        size_t mid = left + (right - left) / 2;
+        if (cp < unicode_nfkc_cf_map[mid].code) {
+            right = mid;
+        } else if (cp > unicode_nfkc_cf_map[mid].code) {
+            left = mid + 1;
+        } else {
+            *index = unicode_nfkc_cf_map[mid].index;
+            *len = unicode_nfkc_cf_map[mid].len;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int unicode_nfkc_scf_find(uint32_t cp, size_t *index, uint8_t *len) {
+    size_t left = 0;
+    size_t right = unicode_nfkc_scf_map_len;
+    while (left < right) {
+        size_t mid = left + (right - left) / 2;
+        if (cp < unicode_nfkc_scf_map[mid].code) {
+            right = mid;
+        } else if (cp > unicode_nfkc_scf_map[mid].code) {
+            left = mid + 1;
+        } else {
+            *index = unicode_nfkc_scf_map[mid].index;
+            *len = unicode_nfkc_scf_map[mid].len;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int unicode_is_composition_exclusion(uint32_t cp) {
+    return unicode_uint32_list_contains(unicode_exclusions, unicode_exclusions_len, cp);
+}
+
+int unicode_get_nfd_qc(uint32_t cp) { return unicode_qc_lookup(unicode_nfd_qc, unicode_nfd_qc_len, cp); }
+int unicode_get_nfc_qc(uint32_t cp) { return unicode_qc_lookup(unicode_nfc_qc, unicode_nfc_qc_len, cp); }
+int unicode_get_nfkd_qc(uint32_t cp) { return unicode_qc_lookup(unicode_nfkd_qc, unicode_nfkd_qc_len, cp); }
+int unicode_get_nfkc_qc(uint32_t cp) { return unicode_qc_lookup(unicode_nfkc_qc, unicode_nfkc_qc_len, cp); }
+
+size_t unicode_nfkc_cf(uint32_t cp, uint32_t out[UNICODE_NFKC_CF_MAX]) {
+    size_t index;
+    uint8_t len;
+    if (unicode_nfkc_cf_find(cp, &index, &len)) {
+        for (size_t i = 0; i < len; i++)
+            out[i] = unicode_nfkc_cf_data[index + i];
+        return len;
+    }
+    out[0] = cp;
+    return 1;
+}
+
+size_t unicode_nfkc_scf(uint32_t cp, uint32_t out[UNICODE_NFKC_SCF_MAX]) {
+    size_t index;
+    uint8_t len;
+    if (unicode_nfkc_scf_find(cp, &index, &len)) {
+        for (size_t i = 0; i < len; i++)
+            out[i] = unicode_nfkc_scf_data[index + i];
+        return len;
+    }
+    out[0] = cp;
+    return 1;
+}
+
+int unicode_changes_when_nfkc_casefolded(uint32_t cp) {
+    return unicode_range_contains(unicode_cwkcf, unicode_cwkcf_len, cp);
 }

--- a/unicode.h
+++ b/unicode.h
@@ -11,4 +11,17 @@ size_t unicode_tolower_full_locale(uint32_t cp, const char *locale, uint32_t out
 size_t unicode_toupper_full_locale(uint32_t cp, const char *locale, uint32_t out[3]);
 int unicode_collation_lookup(uint32_t cp, uint16_t *primary, uint16_t *secondary, uint16_t *tertiary);
 
+#define UNICODE_NFKC_CF_MAX 18
+#define UNICODE_NFKC_SCF_MAX 18
+#define UNICODE_QC_YES 2
+
+int unicode_is_composition_exclusion(uint32_t cp);
+int unicode_get_nfd_qc(uint32_t cp);
+int unicode_get_nfc_qc(uint32_t cp);
+int unicode_get_nfkd_qc(uint32_t cp);
+int unicode_get_nfkc_qc(uint32_t cp);
+size_t unicode_nfkc_cf(uint32_t cp, uint32_t out[UNICODE_NFKC_CF_MAX]);
+size_t unicode_nfkc_scf(uint32_t cp, uint32_t out[UNICODE_NFKC_SCF_MAX]);
+int unicode_changes_when_nfkc_casefolded(uint32_t cp);
+
 #endif /* UNICODE_H */


### PR DESCRIPTION
## Summary
- implement derived normalization and composition-exclusion lookups
- expose new lookup prototypes in `unicode.h`
- test new helpers in `test_unicode.c`
- update Makefile target to generate needed headers

## Testing
- `make test_unicode`

------
https://chatgpt.com/codex/tasks/task_e_68637dd1b4e8833391dceddb6034e7e1