### PR TITLE
Implement Unicode NFC normalization

### DIFF
--- a/unicode.c
+++ b/unicode.c
@@ -1,5 +1,7 @@
 #include "unicode.h"
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 #include "unicode_db.h"
 #include "unicode_collation.h"
 #include "unicode_special_casing.h"
@@ -199,6 +201,134 @@ static int unicode_range_contains(const unicode_range_t *ranges, size_t len, uin
     return 0;
 }
 
+/* helper: get canonical combining class */
+static int unicode_combining_class(uint32_t cp) {
+    size_t idx;
+    if (unicode_find_index(cp, &idx)) {
+        return atoi(unicode_db[idx].combining_class);
+    }
+    return 0;
+}
+
+/* parse decomposition string as sequence of code points
+   returns number of code points parsed, or 0 if none or compatibility */
+static size_t unicode_parse_decomp(const char *str, uint32_t *out, size_t cap) {
+    if (!str || !str[0])
+        return 0;
+    if (str[0] == '<')
+        return 0; /* compatibility mapping */
+    size_t n = 0;
+    const char *p = str;
+    while (*p && n < cap) {
+        while (*p == ' ')
+            p++;
+        char *end;
+        unsigned long v = strtoul(p, &end, 16);
+        if (end == p)
+            break;
+        out[n++] = (uint32_t)v;
+        p = end;
+        while (*p == ' ')
+            p++;
+    }
+    return n;
+}
+
+/* canonical decomposition of single code point */
+static size_t unicode_decompose_char(uint32_t cp, uint32_t *out, size_t cap) {
+    /* Hangul decomposition */
+    const uint32_t SBase = 0xAC00;
+    const uint32_t LBase = 0x1100;
+    const uint32_t VBase = 0x1161;
+    const uint32_t TBase = 0x11A7;
+    const int LCount = 19;
+    const int VCount = 21;
+    const int TCount = 28;
+    const int NCount = VCount * TCount;
+    const int SCount = LCount * NCount;
+
+    if (cp >= SBase && cp < SBase + SCount) {
+        int SIndex = cp - SBase;
+        uint32_t L = LBase + SIndex / NCount;
+        uint32_t V = VBase + (SIndex % NCount) / TCount;
+        uint32_t T = TBase + SIndex % TCount;
+        out[0] = L;
+        out[1] = V;
+        if (T != TBase && cap >= 3) {
+            out[2] = T;
+            return 3;
+        }
+        return 2;
+    }
+
+    size_t idx;
+    if (unicode_find_index(cp, &idx)) {
+        uint32_t tmp[18];
+        size_t n = unicode_parse_decomp(unicode_db[idx].decomposition, tmp, 18);
+        if (n > 0 && n <= cap) {
+            for (size_t i = 0; i < n; i++)
+                out[i] = tmp[i];
+            return n;
+        }
+    }
+    if (cap > 0)
+        out[0] = cp;
+    return 1;
+}
+
+/* recursive canonical decomposition */
+static size_t unicode_decompose(uint32_t cp, uint32_t *out, size_t cap) {
+    uint32_t tmp[18];
+    size_t n = unicode_decompose_char(cp, tmp, 18);
+    size_t total = 0;
+    for (size_t i = 0; i < n && total < cap; i++) {
+        if (tmp[i] == cp && n == 1) {
+            out[total++] = tmp[i];
+        } else {
+            total += unicode_decompose(tmp[i], out + total, cap - total);
+        }
+    }
+    return total;
+}
+
+/* lookup composition of pair */
+static int unicode_compose_pair(uint32_t a, uint32_t b, uint32_t *out) {
+    const uint32_t SBase = 0xAC00;
+    const uint32_t LBase = 0x1100;
+    const uint32_t VBase = 0x1161;
+    const uint32_t TBase = 0x11A7;
+    const int LCount = 19;
+    const int VCount = 21;
+    const int TCount = 28;
+    const int NCount = VCount * TCount;
+    const int SCount = LCount * NCount;
+
+    if (LBase <= a && a < LBase + LCount && VBase <= b && b < VBase + VCount) {
+        int LIndex = a - LBase;
+        int VIndex = b - VBase;
+        *out = SBase + (LIndex * VCount + VIndex) * TCount;
+        return 1;
+    }
+    if (SBase <= a && a < SBase + SCount && (a - SBase) % TCount == 0 &&
+        TBase < b && b < TBase + TCount) {
+        int TIndex = b - TBase;
+        *out = a + TIndex;
+        return 1;
+    }
+
+    uint32_t seq[3];
+    for (size_t i = 0; i < unicode_db_len; i++) {
+        size_t n = unicode_parse_decomp(unicode_db[i].decomposition, seq, 3);
+        if (n == 2 && seq[0] == a && seq[1] == b) {
+            uint32_t cp = unicode_db[i].code;
+            if (!unicode_is_composition_exclusion(cp)) {
+                *out = cp;
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
 static int unicode_nfkc_cf_find(uint32_t cp, size_t *index, uint8_t *len) {
     size_t left = 0;
     size_t right = unicode_nfkc_cf_map_len;
@@ -273,7 +403,62 @@ int unicode_changes_when_nfkc_casefolded(uint32_t cp) {
 }
 
 size_t unicode_normalize(uint32_t *buf, size_t len, size_t cap) {
-    (void)cap;
-    /* TODO: full Unicode normalization (NFC) */
-    return len;
+    if (!buf)
+        return 0;
+
+    uint32_t *tmp = (uint32_t *)malloc(sizeof(uint32_t) * cap);
+    if (!tmp)
+        return len;
+
+    /* Canonical decomposition with ordering */
+    size_t out_len = 0;
+    size_t segment_start = 0;
+    for (size_t i = 0; i < len && out_len < cap; i++) {
+        uint32_t dec[18];
+        size_t dlen = unicode_decompose(buf[i], dec, 18);
+        for (size_t j = 0; j < dlen && out_len < cap; j++) {
+            uint32_t c = dec[j];
+            int cc = unicode_combining_class(c);
+            if (cc == 0) {
+                segment_start = out_len;
+                tmp[out_len++] = c;
+            } else {
+                size_t k = out_len;
+                while (k > segment_start && unicode_combining_class(tmp[k - 1]) > cc) {
+                    tmp[k] = tmp[k - 1];
+                    k--;
+                }
+                tmp[k] = c;
+                out_len++;
+            }
+        }
+    }
+
+    /* Canonical composition */
+    size_t starter = 0;
+    int prev_cc = 0;
+    for (size_t i = 1; i < out_len; i++) {
+        int cc = unicode_combining_class(tmp[i]);
+        uint32_t comp;
+        if (cc != 0 && prev_cc < cc && unicode_compose_pair(tmp[starter], tmp[i], &comp)) {
+            tmp[starter] = comp;
+            memmove(tmp + i, tmp + i + 1, (out_len - i - 1) * sizeof(uint32_t));
+            out_len--;
+            i--; /* re-evaluate at same index */
+            prev_cc = 0;
+            continue;
+        }
+        if (cc == 0) {
+            starter = i;
+            prev_cc = 0;
+        } else {
+            prev_cc = cc;
+        }
+    }
+
+    if (out_len > cap)
+        out_len = cap;
+    memcpy(buf, tmp, out_len * sizeof(uint32_t));
+    free(tmp);
+    return out_len;
 }


### PR DESCRIPTION
## Summary
- add missing Unicode NFC normalization implementation in `unicode_normalize`
- provide helper routines for combining class lookup, decomposition parsing and composition
- include `<string.h>` for memory operations

## Testing
- `make test_jsstr`
- `make test_mnurl`
- `make test_unicode`

------
https://chatgpt.com/codex/tasks/task_e_6863858e6b308333bb8e02334e12e71d